### PR TITLE
Fix incorrect use of mmap, and incorrect platform recognition for tls

### DIFF
--- a/examples/getrss.c
+++ b/examples/getrss.c
@@ -13,7 +13,7 @@
 #include <unistd.h>
 #include <sys/resource.h>
 #include <mach/mach.h>
-#elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+#elif defined(__OpenBSD__) || defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
 #include <unistd.h>
 #include <sys/resource.h>
 #include <stdio.h>

--- a/src/cache.c
+++ b/src/cache.c
@@ -21,6 +21,7 @@
 
 #include <atomics.h>
 #include <cache.h>
+#include <errno.h>
 
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
@@ -142,8 +143,8 @@ cache_create(size_t _cache_size, size_t _max_size)
         exit(1);
     }
 
-    cache_table = (cache_entry_t)mmap(0, cache_max * sizeof(struct cache_entry), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
-    cache_status = (uint32_t*)mmap(0, cache_max * sizeof(uint32_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+    cache_table = (cache_entry_t)mmap(0, cache_max * sizeof(struct cache_entry), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    cache_status = (uint32_t*)mmap(0, cache_max * sizeof(uint32_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
     if (cache_table == (cache_entry_t)-1 || cache_status == (uint32_t*)-1) {
         fprintf(stderr, "cache_create: Unable to allocate memory!\n");

--- a/src/lace.c
+++ b/src/lace.c
@@ -539,7 +539,7 @@ lace_spawn_worker(int worker, size_t stacksize, void* (*fun)(void*), void* arg)
         exit(1);
     }
 #else
-    void *stack_location = mmap(NULL, stacksize + pagesize, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, 0, 0);
+    void *stack_location = mmap(NULL, stacksize + pagesize, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
     if (stack_location == MAP_FAILED) {
         fprintf(stderr, "Lace error: Cannot allocate program stack, errno=%d!\n", errno);
         exit(1);

--- a/src/llmsset.c
+++ b/src/llmsset.c
@@ -316,8 +316,8 @@ llmsset_create(size_t initial_size, size_t max_size)
     /* This implementation of "resizable hash table" allocates the max_size table in virtual memory,
        but only uses the "actual size" part in real memory */
 
-    dbs->table = (uint64_t*)mmap(0, dbs->max_size * 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
-    dbs->data = (uint8_t*)mmap(0, dbs->max_size * 16, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+    dbs->table = (uint64_t*)mmap(0, dbs->max_size * 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    dbs->data = (uint8_t*)mmap(0, dbs->max_size * 16, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (dbs->table == (uint64_t*)-1 || dbs->data == (uint8_t*)-1) {
         fprintf(stderr, "llmsset_create: Unable to allocate memory!\n");
         exit(1);

--- a/src/refs.c
+++ b/src/refs.c
@@ -127,7 +127,7 @@ refs_resize(refs_table_t *tbl)
     if (count*4 > tbl->refs_size) new_size *= 2;
 
     // allocate new table
-    uint64_t *new_table = (uint64_t*)mmap(0, new_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, 0, 0);
+    uint64_t *new_table = (uint64_t*)mmap(0, new_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     if (new_table == (uint64_t*)-1) {
         fprintf(stderr, "refs: Unable to allocate memory!\n");
         exit(1);
@@ -301,7 +301,7 @@ refs_create(refs_table_t *tbl, size_t _refs_size)
     }
 
     tbl->refs_size = _refs_size;
-    tbl->refs_table = (uint64_t*)mmap(0, tbl->refs_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, 0, 0);
+    tbl->refs_table = (uint64_t*)mmap(0, tbl->refs_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     if (tbl->refs_table == (uint64_t*)-1) {
         fprintf(stderr, "refs: Unable to allocate memory!\n");
         exit(1);
@@ -402,7 +402,7 @@ protect_resize(refs_table_t *tbl)
     if (count*4 > tbl->refs_size) new_size *= 2;
 
     // allocate new table
-    uint64_t *new_table = (uint64_t*)mmap(0, new_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, 0, 0);
+    uint64_t *new_table = (uint64_t*)mmap(0, new_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     if (new_table == (uint64_t*)-1) {
         fprintf(stderr, "refs: Unable to allocate memory!\n");
         exit(1);
@@ -570,7 +570,7 @@ protect_create(refs_table_t *tbl, size_t _refs_size)
     }
 
     tbl->refs_size = _refs_size;
-    tbl->refs_table = (uint64_t*)mmap(0, tbl->refs_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, 0, 0);
+    tbl->refs_table = (uint64_t*)mmap(0, tbl->refs_size * sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     if (tbl->refs_table == (uint64_t*)-1) {
         fprintf(stderr, "refs: Unable to allocate memory!\n");
         exit(1);

--- a/src/tls.h
+++ b/src/tls.h
@@ -8,13 +8,13 @@
 #ifndef TLS_H
 #define TLS_H
 
-#ifdef __ELF__ // use gcc thread-local storage (i.e. __thread variables)
+#ifdef __LINUX__ // use gcc thread-local storage (i.e. __thread variables)
 #define DECLARE_THREAD_LOCAL(name, type) __thread type name
 #define INIT_THREAD_LOCAL(name)
 #define SET_THREAD_LOCAL(name, value) name = value
 #define LOCALIZE_THREAD_LOCAL(name, type)
 
-#else//!__ELF__
+#else//!__LINUX__
 
 #include <pthread.h>
 


### PR DESCRIPTION
Sylvan wasn't able to build on OpenBSD due to a not checking for OpenBSD in getrss.c, and checking for the ELF definition for tls support, while OpenBSD doesn't support that. 

Also, mmap was used incorrectly. fd should be -1 when not passing a file.
