### PR TITLE
Use pkg-config for hwloc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,8 @@ LT_INIT
 PKG_PROG_PKG_CONFIG
 m4_pattern_forbid([^PKG_[A-Z_]+$], [missing some pkg-config macros (pkg-config package)])
 
-AC_CHECKING([for any suitable hwloc installation])
-AC_CHECK_LIB([hwloc], [hwloc_topology_init], [AC_CHECK_HEADER([hwloc.h], [hwloc=yes])])
+PKG_CHECK_MODULES([HWLOC], [hwloc], [hwloc=yes],
+    [AC_MSG_WARN(No suitable hwloc installation found)])
 AM_CONDITIONAL([HAVE_LIBHWLOC], [test "$hwloc" = "yes"])
 
 AC_CANONICAL_HOST

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,9 @@ AX_CHECK_COMPILE_FLAG([-std=c11],,[AC_MSG_FAILURE([no acceptable C11 compiler fo
 AC_PROG_CXX
 LT_INIT
 
+PKG_PROG_PKG_CONFIG
+m4_pattern_forbid([^PKG_[A-Z_]+$], [missing some pkg-config macros (pkg-config package)])
+
 AC_CHECKING([for any suitable hwloc installation])
 AC_CHECK_LIB([hwloc], [hwloc_topology_init], [AC_CHECK_HEADER([hwloc.h], [hwloc=yes])])
 AM_CONDITIONAL([HAVE_LIBHWLOC], [test "$hwloc" = "yes"])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,7 @@ libsylvan_la_SOURCES = \
 libsylvan_la_LIBADD = -lm
 
 if HAVE_LIBHWLOC
-libsylvan_la_LIBADD += -lhwloc
+libsylvan_la_LIBADD += $(HWLOC_LIBS)
+libsylvan_la_CFLAGS += $(HWLOC_CFLAGS)
 libsylvan_la_CFLAGS += -DUSE_HWLOC=1
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ libsylvan_la_SOURCES = \
     sylvan_int.h \
     sylvan_ldd.h \
     sylvan_ldd.c \
+    sylvan_ldd_int.h \
     sylvan_mtbdd.h \
     sylvan_mtbdd.c \
     sylvan_mtbdd_int.h \


### PR DESCRIPTION
Using pkg-config for resolving hwloc dependencies
is necessary in the context of static linking.
The old code would output only -lhwloc in both
the case of static linking as well as dynamic linking.
Now one can run configure as follows:
--configure PKG_CONFIG="$(which pkg-config) --static",
this properly outputs: "HWLOC_LIBS='-lhwloc -lm -lnuma -lltdl -lpthread -ldl'",
instead of just HWLOC_LIBS="-lhwloc".