### PR TITLE
Update lace.h

### DIFF
--- a/src/lace.h
+++ b/src/lace.h
@@ -35,6 +35,10 @@
 #  endif
 #endif
 
+#if __cplusplus >= 199711L
+#define register
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
C++11 deprecated the keyword register.