### PR TITLE
Replace CMAKE_SOURCE_DIR by PROJECT_SOURCE_DIR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(WITH_COVERAGE)
     )
 endif()
 
-include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/src)
 include(GNUInstallDirs)
 include(CTest)
 


### PR DESCRIPTION
If you try to add the sylvan folder in an external project, you will get the following problem:
```
[ 70%] Building C object third-party/sylvan/src/CMakeFiles/sylvan.dir/lace.c.o
/home/arias/Work/code/lipn/pmc-sog/thread-sog/third-party/sylvan/src/lace.c:32:10: fatal error: lace.h: No such file or directory
 #include <lace.h>
          ^~~~~~~~
compilation terminated.
make[2]: *** [third-party/sylvan/src/CMakeFiles/sylvan.dir/build.make:63: third-party/sylvan/src/CMakeFiles/sylvan.dir/lace.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1798: third-party/sylvan/src/CMakeFiles/sylvan.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```